### PR TITLE
27 visitor cart item remove

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :build_cart
-  helper_method :current_user, :logged_in?, :admin?, :authorize, :log_in
+  helper_method :current_user, :logged_in?, :admin?, :authorize, :log_in, :current_admin?
 
   def current_user
     @current_user ||= User.find_by(id: session[:user_id])
@@ -12,10 +12,6 @@ class ApplicationController < ActionController::Base
 
   def logged_in?
     !current_user.nil?
-  end
-
-  def current_admin?
-    current_user && current_user.admin?
   end
 
   def current_admin?

--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -8,4 +8,11 @@ class CartController < ApplicationController
     flash[:success] = "You have added #{Item.find(params[:item][:item_id]).title} to your cart!"
     redirect_back(fallback_location: bike_shop_path)
   end
+
+  def destroy
+    session[:shopping_cart].delete(params[:item][:item_id])
+    item = Item.find(params[:item][:item_id])
+    flash[:success] = %Q[You have removed #{(view_context.link_to "#{item.title}", item_path(item))} from your cart!]
+    redirect_back(fallback_location: bike_shop_path)
+  end
 end

--- a/app/views/cart/index.html.slim
+++ b/app/views/cart/index.html.slim
@@ -1,10 +1,20 @@
-ul
+ul style="list-style-type:none;"
   - @items.each do |item|
     li
       = item.title
-      = item.price
+    li
+      '$
+      = '%.2f' % item.price
+    li
       = image_tag("#{item.image}")
+    li
       'Quantity -
       = session[:shopping_cart][item.id.to_s]
+    li
       'Subtotal - $
-      = '%.2f' % (item.price * session[:shopping_cart][item.id.to_s])
+      = '%.2f' % (item.price * session[:shopping_cart][item.id.to_s].to_i)
+    li
+      = form_for(:item, url: bike_shop_path, method: :delete) do |f|
+        = f.hidden_field(:item_id, value: item.id)
+        = f.submit 'Remove Item From Cart'
+

--- a/app/views/items/index.html.slim
+++ b/app/views/items/index.html.slim
@@ -1,8 +1,3 @@
-div class="container"
-  - flash.each do |key, value|
-    div class="alert alert"
-      = value
-
 div class="container-fluid"
   div class="row"
     - @items.each do |item|

--- a/app/views/items/index.html.slim
+++ b/app/views/items/index.html.slim
@@ -26,3 +26,7 @@ div class="container-fluid"
                 = f.number_field :quantity, options = {max: 25, min: 0}
 
               = f.submit 'Add to Cart'
+          li
+            = form_for(:item, url: bike_shop_path, method: :delete) do |f|
+              = f.hidden_field(:item_id, value: item.id)
+              = f.submit 'Remove Item From Cart'

--- a/app/views/items/show.html.slim
+++ b/app/views/items/show.html.slim
@@ -1,3 +1,8 @@
+div class="container"
+  - flash.each do |key, value|
+    div class="alert alert"
+      = value
+
 div 
   h1 = @item.title
   - if @item.is_retired? == true

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -15,5 +15,6 @@ html
     = render 'partials/navbar'
     - flash.each do |message_type, message|
       div class="alert alert-#{message_type}"
-        = message
+        - if message.is_a?(String)
+          = sanitize(message)
     = yield

--- a/app/views/partials/_navbar.html.slim
+++ b/app/views/partials/_navbar.html.slim
@@ -22,14 +22,9 @@ nav class="navbar navbar-default"
           = session[:shopping_cart].values.sum  
       - if current_user
         li
-<<<<<<< HEAD
-          ' Logged in as
-          = current_user.username
-=======
           p
             ' Logged in as
             = current_user.username
->>>>>>> tested admin sees a trip show page, fixed errors for @ user in nav bar
         li
           = link_to 'Log Out', logout_path, method: :delete
       - else

--- a/app/views/trips/show.html.slim
+++ b/app/views/trips/show.html.slim
@@ -26,6 +26,6 @@ h1
     'Zip Code:
     = @trip.zip_code
 
-  - if current_user && current_user.admin?
+  - if current_admin?
     = button_to 'Delete Trip', admin_trip_path(@trip), method: 'delete'
     = button_to 'Edit Trip', edit_admin_trip_path(@trip), method: 'edit'

--- a/app/views/trips/show.html.slim
+++ b/app/views/trips/show.html.slim
@@ -26,11 +26,6 @@ h1
     'Zip Code:
     = @trip.zip_code
 
-<<<<<<< HEAD
-  -if current_user == admin
-   = button_to 'Delete Trip', admin_trip_path(@trip), method: 'delete'
-=======
-  - if current_admin?
+  - if current_user && current_user.admin?
     = button_to 'Delete Trip', admin_trip_path(@trip), method: 'delete'
     = button_to 'Edit Trip', edit_admin_trip_path(@trip), method: 'edit'
->>>>>>> finished testing that admin can see edit/delete while user cannot

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,4 +20,5 @@ Rails.application.routes.draw do
 
   get '/cart', to: "cart#index"
   patch '/bike-shop', to: "cart#update"
+  delete '/bike-shop', to: 'cart#destroy'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,15 +8,8 @@ Rails.application.routes.draw do
 
   resources :stations
 
-<<<<<<< HEAD
-  resources :stations, shallow: true do
-    resources :trips, only: [:show]
-  end
-  
-=======
   resources :trips, only: [:show, :index]
 
->>>>>>> finished testing that admin can see edit/delete while user cannot
   namespace :admin do
     resources :stations
     resources :trips

--- a/spec/features/admin/admin_sees_trip_show_page_spec.rb
+++ b/spec/features/admin/admin_sees_trip_show_page_spec.rb
@@ -57,12 +57,8 @@ describe 'Visit trip show page' do
 
       visit trip_path(trip)
 
-<<<<<<< HEAD
-      expect(current_path).to eq trips_path
-=======
       expect(page).to_not have_button('Edit Trip')
       expect(page).to_not have_button('Delete Trip')
->>>>>>> finished testing that admin can see edit/delete while user cannot
     end
   end
 end

--- a/spec/features/visitors/visitor_can_see_a_cart_with_their_items_spec.rb
+++ b/spec/features/visitors/visitor_can_see_a_cart_with_their_items_spec.rb
@@ -29,6 +29,23 @@ describe 'Visitor' do
       expect(page).to have_content('Subtotal - $ 30.00')
       expect(page).to have_content('Subtotal - $ 110.00')
     end
+
+    it 'can remove an item from the cart, see a flash message with a link to the item show page, and should be shown the cart without the item' do
+      item1 = Item.create(price: 15.00, image: 'http://i0.kym-cdn.com/entries/icons/original/000/003/980/hold-all-these-limes.jpg', description: 'Too many limes', title: 'Bike Limes')
+      item2 = Item.create(price: 22.00, image: 'http://i0.kym-cdn.com/entries/icons/original/000/003/980/hold-all-these-limes.jpg', description: 'Too many limes x2', title: 'Bike Limes Twice')
+      item3 = Item.create(price: 11.00, image: 'http://i0.kym-cdn.com/entries/icons/original/000/003/980/hold-all-these-limes.jpg', description: 'Too many limes x3', title: 'Bike Limes Thrice')
+      item4 = Item.create(price: 8.00, image: 'http://i0.kym-cdn.com/entries/icons/original/000/003/980/hold-all-these-limes.jpg', description: 'Too many limes x4', title: 'Bike Limes Quad')
+
+      page.set_rack_session(shopping_cart: { item1.id => 2, item2.id => 5, item3.id => 5 } )
+      visit(cart_path)
+      within(first('form')) do
+        click_on('Remove Item From Cart')
+      end
+      expect(page).to have_content("You have removed #{item1.title} from your cart!")
+      expect(page).to have_link("#{item1.title}")
+      expect(page).to_not have_content(item1.price)
+      expect(page).to_not have_content(item1.description)
+    end
   end
 
   context 'can log in after viewing their cart' do


### PR DESCRIPTION
## Reference to related issue in repository

## Status
**READY**

## Migrations
NO

## Description
This PR implements the ability to remove an item from a cart for a visitor along with a flash message.

## Impacted Areas in Application
List general components of the application that this PR will affect:
Cart index and associated view, added destroy method to cart.

## @mention members of team who will be responsible for reviewing this PR.
@tywestlie @jamisonordway 